### PR TITLE
Interactive feedback matrix in topic detail to rate without level transition

### DIFF
--- a/src/components/FeedbackSection.tsx
+++ b/src/components/FeedbackSection.tsx
@@ -559,7 +559,7 @@ function UnifiedItemRow({
               onClick={() => setShowComment((v) => !v)}
               className={`w-6 shrink-0 rounded p-1 transition ${
                 hasComment
-                  ? "text-orange-300 hover:bg-zinc-700/60"
+                  ? "text-orange-500 hover:bg-zinc-700/60"
                   : "text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300"
               }`}
               title={commentTooltip}

--- a/src/components/FeedbackSection.tsx
+++ b/src/components/FeedbackSection.tsx
@@ -13,6 +13,9 @@ import { api, type RouterOutputs } from "~/utils/api";
 import { CommentIcon } from "~/components/CommentIcon";
 
 type Transition = RouterOutputs["feedback"]["getTransitionsByTopic"][number];
+type LatestResourceFeedbackData =
+  RouterOutputs["feedback"]["getLatestResourceFeedbackByTopic"];
+type TopicDetailData = NonNullable<RouterOutputs["topic"]["getById"]>;
 
 type ExistingFeedbackItem = Transition["feedbackItems"][number];
 type UpsertFeedbackMutationOptions = Exclude<
@@ -78,7 +81,12 @@ export function FeedbackSection({
   );
 
   const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
+  const expandedIdsRef = useRef(expandedIds);
   const seenTransitionIdsRef = useRef<Set<number> | null>(null);
+
+  useEffect(() => {
+    expandedIdsRef.current = expandedIds;
+  }, [expandedIds]);
 
   useEffect(() => {
     seenTransitionIdsRef.current = null;
@@ -114,16 +122,136 @@ export function FeedbackSection({
     (opts: UpsertFeedbackMutationOptions) =>
       api.feedback.upsertFeedbackItem.useMutation(opts),
     {
+      onMutate: async (vars) => {
+        const input = vars as {
+          topicId: number;
+          type: "resource" | "user" | "free_text";
+          topicLinkId?: number | null;
+          helpfulnessRating?: HelpfulnessRating | null;
+        };
+        if (
+          input.type !== "resource" ||
+          input.topicLinkId == null ||
+          input.helpfulnessRating === undefined
+        ) {
+          return;
+        }
+        const topicLinkId = input.topicLinkId;
+        const helpfulnessRating = input.helpfulnessRating;
+
+        const latestResourceFeedbackInput = { topicId: input.topicId };
+        await Promise.all([
+          utils.topic.getById.cancel({ id: input.topicId }),
+          utils.feedback.getLatestResourceFeedbackByTopic.cancel(
+            latestResourceFeedbackInput,
+          ),
+        ]);
+
+        const previousTopic = utils.topic.getById.getData({
+          id: input.topicId,
+        });
+        const previousLatestResourceFeedback =
+          utils.feedback.getLatestResourceFeedbackByTopic.getData(
+            latestResourceFeedbackInput,
+          );
+        const previousRating =
+          previousLatestResourceFeedback?.find(
+            (item) =>
+              item.type === "resource" && item.topicLinkId === topicLinkId,
+          )?.helpfulnessRating ?? null;
+
+        utils.topic.getById.setData({ id: input.topicId }, (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            topicLinks: old.topicLinks.map((link) => {
+              if (link.id !== topicLinkId) return link;
+              const ratingCounts = { ...link.ratingCounts };
+              if (previousRating) {
+                ratingCounts[previousRating] = Math.max(
+                  0,
+                  ratingCounts[previousRating] - 1,
+                );
+              }
+              if (helpfulnessRating) {
+                ratingCounts[helpfulnessRating] += 1;
+              }
+              return { ...link, ratingCounts };
+            }),
+          } satisfies TopicDetailData;
+        });
+
+        if (previousLatestResourceFeedback) {
+          utils.feedback.getLatestResourceFeedbackByTopic.setData(
+            latestResourceFeedbackInput,
+            (old) => {
+              if (!old) return old;
+              const existing = old.find(
+                (item) =>
+                  item.type === "resource" && item.topicLinkId === topicLinkId,
+              );
+              if (existing) {
+                return old.map((item) =>
+                  item.type === "resource" && item.topicLinkId === topicLinkId
+                    ? {
+                        ...item,
+                        helpfulnessRating,
+                      }
+                    : item,
+                );
+              }
+              if (helpfulnessRating == null) return old;
+              return [
+                ...old,
+                {
+                  id: topicLinkId * -1,
+                  type: "resource" as const,
+                  topicLinkId,
+                  helpfulnessRating,
+                  comment: null,
+                },
+              ];
+            },
+          );
+        }
+
+        return {
+          latestResourceFeedbackInput,
+          previousTopic,
+          previousLatestResourceFeedback,
+        };
+      },
       onSuccess: () => {
         setFeedbackError(null);
       },
-      onError: (error) => {
+      onError: (error, _vars, ctx) => {
+        const context = ctx as
+          | {
+              latestResourceFeedbackInput: { topicId: number };
+              previousTopic?: TopicDetailData;
+              previousLatestResourceFeedback?: LatestResourceFeedbackData;
+            }
+          | undefined;
+        if (context) {
+          utils.topic.getById.setData(
+            { id: context.latestResourceFeedbackInput.topicId },
+            context.previousTopic,
+          );
+          utils.feedback.getLatestResourceFeedbackByTopic.setData(
+            context.latestResourceFeedbackInput,
+            context.previousLatestResourceFeedback,
+          );
+        }
         setFeedbackError(
           getMutationErrorMessage(error, "Failed to save feedback item."),
         );
       },
       refresh: [
         () => utils.feedback.getTransitionsByTopic.invalidate({ topicId }),
+        () =>
+          utils.feedback.getLatestResourceFeedbackByTopic.invalidate({
+            topicId,
+          }),
         () => utils.feedback.getRecentTransitions.invalidate(),
         () => utils.topic.getById.invalidate({ id: topicId }),
       ],
@@ -144,6 +272,10 @@ export function FeedbackSection({
       },
       refresh: [
         () => utils.feedback.getTransitionsByTopic.invalidate({ topicId }),
+        () =>
+          utils.feedback.getLatestResourceFeedbackByTopic.invalidate({
+            topicId,
+          }),
         () => utils.feedback.getRecentTransitions.invalidate(),
         () => utils.topic.getById.invalidate({ id: topicId }),
       ],
@@ -166,6 +298,10 @@ export function FeedbackSection({
       },
       refresh: [
         () => utils.feedback.getTransitionsByTopic.invalidate({ topicId }),
+        () =>
+          utils.feedback.getLatestResourceFeedbackByTopic.invalidate({
+            topicId,
+          }),
         () => utils.feedback.getRecentTransitions.invalidate(),
         () => utils.topic.getById.invalidate({ id: topicId }),
       ],
@@ -175,16 +311,43 @@ export function FeedbackSection({
     (opts: SkipTransitionFeedbackMutationOptions) =>
       api.feedback.skipTransitionFeedback.useMutation(opts),
     {
+      onMutate: (vars) => {
+        const input = vars as { transitionId: number };
+        const wasExpanded = expandedIdsRef.current.has(input.transitionId);
+        setExpandedIds((prev) => {
+          const next = new Set(prev);
+          next.delete(input.transitionId);
+          expandedIdsRef.current = next;
+          return next;
+        });
+        setFeedbackError(null);
+        return { transitionId: input.transitionId, wasExpanded };
+      },
       onSuccess: () => {
         setFeedbackError(null);
       },
-      onError: (error) => {
+      onError: (error, _vars, ctx) => {
+        const context = ctx as
+          | { transitionId: number; wasExpanded: boolean }
+          | undefined;
+        if (context?.wasExpanded) {
+          setExpandedIds((prev) => {
+            const next = new Set(prev);
+            next.add(context.transitionId);
+            expandedIdsRef.current = next;
+            return next;
+          });
+        }
         setFeedbackError(
           getMutationErrorMessage(error, "Failed to skip feedback."),
         );
       },
       refresh: [
         () => utils.feedback.getTransitionsByTopic.invalidate({ topicId }),
+        () =>
+          utils.feedback.getLatestResourceFeedbackByTopic.invalidate({
+            topicId,
+          }),
         () => utils.feedback.getRecentTransitions.invalidate(),
         () => utils.topic.getById.invalidate({ id: topicId }),
       ],

--- a/src/components/TopicList.tsx
+++ b/src/components/TopicList.tsx
@@ -37,7 +37,7 @@ export function TopicList() {
   const [excitedUpdatingTopicId, setExcitedUpdatingTopicId] = useState<
     number | null
   >(null);
-  const { viewerUser } = useViewerAccess();
+  const { viewerUser, isPending: viewerPending } = useViewerAccess();
   const { data: allTopics, isLoading } = api.topic.list.useQuery();
   const { data: tags, isPending: tagsPending } = api.topic.listTags.useQuery();
   const {
@@ -168,6 +168,7 @@ export function TopicList() {
   );
   const initialSortReady =
     !isLoading &&
+    !viewerPending &&
     (!viewerUser ||
       (statusesFetched && bookmarksFetched && excitedToTeachFetched));
   useEffect(() => {
@@ -195,10 +196,19 @@ export function TopicList() {
     currentSortKey,
   ]);
   const sortDirty = initialSortApplied && currentSortKey !== lastAppliedSortKey;
+  const isInitialOrderStable = !viewerUser || initialSortApplied;
   const shouldHoldForInitialRender =
-    isLoading || !isStoredTagLoaded || tagsPending;
+    isLoading ||
+    viewerPending ||
+    !isStoredTagLoaded ||
+    tagsPending ||
+    !initialSortReady ||
+    !isInitialOrderStable;
   const isListRendered = !shouldHoldForInitialRender;
-  useInitialActiveTopicScroll(activeTopicId, isListRendered);
+  useInitialActiveTopicScroll(
+    activeTopicId,
+    isListRendered && isInitialOrderStable,
+  );
   const topicsById = useMemo(
     () => new Map(allTopicsList.map((topic) => [topic.id, topic])),
     [allTopicsList],

--- a/src/features/topic-detail/TopicDetail.tsx
+++ b/src/features/topic-detail/TopicDetail.tsx
@@ -5,13 +5,13 @@ import { CommentIcon } from "~/components/CommentIcon";
 import {
   DebouncedTextarea,
   FeedbackSection,
-  HelpfulnessSelect,
 } from "~/components/FeedbackSection";
 import { TopicAffordanceIcon } from "~/components/TopicAffordanceIcon";
 import { UnderstandingLevelCheckboxes } from "~/components/UnderstandingLevelCheckboxes";
 import { useAppMutation } from "~/hooks/useAppMutation";
 import { useTopicStatusMutations } from "~/hooks/useTopicStatusMutations";
 import { useViewerAccess } from "~/hooks/useViewerAccess";
+import { getErrorMessage, showGlobalErrorToast } from "~/lib/globalErrorToast";
 import type { HelpfulnessRating } from "~/shared/feedbackTypes";
 import { HELPFULNESS_RATINGS } from "~/shared/feedbackTypes";
 import type { UnderstandingLevel } from "~/shared/understandingLevels";
@@ -142,9 +142,12 @@ export function TopicDetail({
     { topicId: id },
     { enabled: !!viewerUser && !Number.isNaN(id) },
   );
-  const [rateMode, setRateMode] = useState(false);
-  const [manualRateLevel, setManualRateLevel] =
-    useState<UnderstandingLevel | null>(null);
+  const serverLevel =
+    topic && statuses
+      ? statuses.find((s) => s.topicId === topic.id)?.level
+      : undefined;
+  const currentLevel = serverLevel;
+  const hasResolvedViewerStatus = !!viewerUser && !!statuses;
   const [resourceSuggestionInput, setResourceSuggestionInput] = useState("");
   const [resourceSuggestionMessage, setResourceSuggestionMessage] = useState<{
     type: "success" | "error";
@@ -181,8 +184,8 @@ export function TopicDetail({
   );
   const { data: manualFeedback } =
     api.feedback.getManualFeedbackByTopic.useQuery(
-      { topicId: id, level: manualRateLevel },
-      { enabled: !!viewerUser && !Number.isNaN(id) && rateMode },
+      { topicId: id, level: currentLevel ?? null },
+      { enabled: hasResolvedViewerStatus && !Number.isNaN(id) },
     );
   const ensureManualTransition = useAppMutation(
     (
@@ -193,9 +196,7 @@ export function TopicDetail({
         undefined
       >,
     ) => api.feedback.ensureManualFeedbackTransition.useMutation(opts),
-    {
-      refresh: [() => utils.feedback.getManualFeedbackByTopic.invalidate()],
-    },
+    {},
   );
   const upsertManualFeedback = useAppMutation(
     (
@@ -205,24 +206,124 @@ export function TopicDetail({
       >,
     ) => api.feedback.upsertFeedbackItem.useMutation(opts),
     {
-      refresh: [
-        () => utils.feedback.getManualFeedbackByTopic.invalidate(),
-        () => utils.feedback.getTransitionsByTopic.invalidate({ topicId: id }),
-        () => utils.feedback.getRecentTransitions.invalidate(),
-        () => utils.topic.getById.invalidate({ id }),
-      ],
+      onMutate: async (vars) => {
+        const input = vars as ManualResourceUpsertInput;
+        if (
+          input.type !== "resource" ||
+          input.helpfulnessRating === undefined
+        ) {
+          return;
+        }
+
+        const manualFeedbackInput = {
+          topicId: input.topicId,
+          level: currentLevel ?? null,
+        };
+        await Promise.all([
+          utils.topic.getById.cancel({ id: input.topicId }),
+          utils.feedback.getManualFeedbackByTopic.cancel(manualFeedbackInput),
+        ]);
+
+        const previousTopic = utils.topic.getById.getData({
+          id: input.topicId,
+        });
+        const previousManualFeedback =
+          utils.feedback.getManualFeedbackByTopic.getData(manualFeedbackInput);
+        const previousRating =
+          previousManualFeedback?.feedbackItems.find(
+            (item) =>
+              item.type === "resource" &&
+              item.topicLinkId === input.topicLinkId,
+          )?.helpfulnessRating ?? null;
+
+        utils.topic.getById.setData({ id: input.topicId }, (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            topicLinks: old.topicLinks.map((link) => {
+              if (link.id !== input.topicLinkId) return link;
+              const ratingCounts = { ...link.ratingCounts };
+              if (previousRating) {
+                ratingCounts[previousRating] = Math.max(
+                  0,
+                  ratingCounts[previousRating] - 1,
+                );
+              }
+              if (input.helpfulnessRating) {
+                ratingCounts[input.helpfulnessRating] += 1;
+              }
+              return { ...link, ratingCounts };
+            }),
+          } satisfies TopicDetailData;
+        });
+
+        if (previousManualFeedback) {
+          utils.feedback.getManualFeedbackByTopic.setData(
+            manualFeedbackInput,
+            (old) => {
+              if (!old) return old;
+              if (old.transitionId === null) return old;
+              return {
+                ...old,
+                feedbackItems: old.feedbackItems.map((item) =>
+                  item.type === "resource" &&
+                  item.topicLinkId === input.topicLinkId
+                    ? {
+                        ...item,
+                        helpfulnessRating: input.helpfulnessRating ?? null,
+                      }
+                    : item,
+                ),
+              };
+            },
+          );
+        }
+
+        return {
+          manualFeedbackInput,
+          previousTopic,
+          previousManualFeedback,
+        };
+      },
+      onError: (error, _vars, ctx) => {
+        const context = ctx as
+          | {
+              manualFeedbackInput: {
+                topicId: number;
+                level: UnderstandingLevel | null;
+              };
+              previousTopic?: TopicDetailData;
+              previousManualFeedback?: ManualFeedbackData;
+            }
+          | undefined;
+        if (context) {
+          utils.topic.getById.setData(
+            { id: context.manualFeedbackInput.topicId },
+            context.previousTopic,
+          );
+          utils.feedback.getManualFeedbackByTopic.setData(
+            context.manualFeedbackInput,
+            context.previousManualFeedback,
+          );
+        }
+        showGlobalErrorToast(
+          getErrorMessage(error, "Failed to save resource feedback."),
+        );
+      },
+      refresh: [() => utils.feedback.getManualFeedbackByTopic.invalidate()],
     },
   );
+  const canRateResources =
+    hasResolvedViewerStatus &&
+    manualFeedback !== undefined &&
+    !ensureManualTransition.isPending &&
+    !upsertManualFeedback.isPending;
+  const showResourceFeedbackControls = !!viewerUser;
   const isBookmarked = topic ? (bookmarkedIds ?? []).includes(topic.id) : false;
   const isExcitedToTeach = topic
     ? (excitedToTeachIds ?? []).includes(topic.id)
     : false;
 
-  const serverLevel =
-    topic && statuses
-      ? statuses.find((s) => s.topicId === topic.id)?.level
-      : undefined;
-  const currentLevel = serverLevel;
   // Un-starring is always allowed (cleans up stale records after a level downgrade);
   // only new excited-to-teach marks require a teacher level.
   const starDisabledReason =
@@ -232,19 +333,8 @@ export function TopicDetail({
   const isTopicLoading = !Number.isNaN(id) && isLoading;
   const isTopicMissing = !isTopicLoading && !topic;
 
-  useEffect(() => {
-    if (!rateMode) return;
-    const normalizedCurrentLevel = currentLevel ?? null;
-    if (normalizedCurrentLevel !== manualRateLevel) {
-      setRateMode(false);
-      setManualRateLevel(null);
-    }
-  }, [rateMode, currentLevel, manualRateLevel]);
-
   // Reset transient UI when navigating between topics (e.g. inside preview pane).
   useEffect(() => {
-    setRateMode(false);
-    setManualRateLevel(null);
     setResourceSuggestionInput("");
     setResourceSuggestionMessage(null);
   }, [topicId]);
@@ -366,48 +456,21 @@ export function TopicDetail({
                 <h2 className="bg-clip-text text-lg font-semibold text-zinc-100">
                   Resources
                 </h2>
-                {viewerUser && (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setRateMode((v) => {
-                        const next = !v;
-                        if (next) {
-                          setManualRateLevel(currentLevel ?? null);
-                        }
-                        return next;
-                      });
-                    }}
-                    className={`rounded p-1 transition ${
-                      rateMode
-                        ? "text-orange-400 hover:bg-zinc-800"
-                        : "text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300"
-                    }`}
-                    title={rateMode ? "Exit rating mode" : "Rate resources"}
-                  >
-                    <svg
-                      viewBox="0 0 20 20"
-                      fill="currentColor"
-                      className="h-4 w-4"
-                    >
-                      <path d="M2.695 14.763l-1.262 3.154a.5.5 0 00.65.65l3.155-1.262a4 4 0 001.343-.885L17.5 5.5a2.121 2.121 0 00-3-3L3.58 13.42a4 4 0 00-.885 1.343z" />
-                    </svg>
-                  </button>
-                )}
                 <div className="flex-1" />
-                {!rateMode && (
-                  <div className="flex shrink-0 items-center font-mono text-xs text-zinc-500">
-                    {HELPFULNESS_RATINGS.map((r) => (
-                      <span
-                        key={r}
-                        className="w-4 text-center"
-                        title={HELPFULNESS_RATING_HEADER_TITLES[r]}
-                      >
-                        {HELPFULNESS_RATING_GLYPHS[r]}
-                      </span>
-                    ))}
-                  </div>
-                )}
+                <div className="flex shrink-0 items-center gap-0.5 font-mono text-xs text-zinc-500">
+                  {HELPFULNESS_RATINGS.map((r) => (
+                    <span
+                      key={r}
+                      className="h-4 w-4 text-center leading-4"
+                      title={HELPFULNESS_RATING_HEADER_TITLES[r]}
+                    >
+                      {HELPFULNESS_RATING_GLYPHS[r]}
+                    </span>
+                  ))}
+                  {showResourceFeedbackControls && (
+                    <span className="h-4 w-6" aria-hidden="true" />
+                  )}
+                </div>
               </div>
               {topic.guidance && (
                 <p className="mb-3 text-sm text-zinc-400">{topic.guidance}</p>
@@ -417,7 +480,8 @@ export function TopicDetail({
                   <li key={link.id}>
                     <InlineRateableResource
                       link={link}
-                      rateMode={rateMode}
+                      canRate={canRateResources}
+                      showCommentControl={showResourceFeedbackControls}
                       manualFeedbackItems={manualFeedback?.feedbackItems ?? []}
                       onUpsert={async (input) => {
                         let transitionId = manualFeedback?.transitionId ?? null;
@@ -425,7 +489,7 @@ export function TopicDetail({
                           const created =
                             await ensureManualTransition.mutateAsync({
                               topicId: id,
-                              level: manualRateLevel,
+                              level: currentLevel ?? null,
                             });
                           transitionId = created.transitionId;
                         }
@@ -607,6 +671,8 @@ function RelatedTopicChip({
 
 type ManualFeedbackItem =
   RouterOutputs["feedback"]["getManualFeedbackByTopic"]["feedbackItems"][number];
+type ManualFeedbackData = RouterOutputs["feedback"]["getManualFeedbackByTopic"];
+type TopicDetailData = NonNullable<RouterOutputs["topic"]["getById"]>;
 
 type ManualResourceUpsertInput = {
   topicId: number;
@@ -620,7 +686,8 @@ type ManualResourceUpsertInput = {
 
 function InlineRateableResource({
   link,
-  rateMode,
+  canRate,
+  showCommentControl,
   manualFeedbackItems,
   onUpsert,
 }: {
@@ -631,7 +698,8 @@ function InlineRateableResource({
     comment: string | null;
     ratingCounts: Record<HelpfulnessRating, number>;
   };
-  rateMode: boolean;
+  canRate: boolean;
+  showCommentControl: boolean;
   manualFeedbackItems: ManualFeedbackItem[];
   onUpsert: (
     input: Omit<ManualResourceUpsertInput, "topicId" | "transitionId">,
@@ -644,19 +712,24 @@ function InlineRateableResource({
   const [rating, setRating] = useState<HelpfulnessRating | null>(null);
   const [comment, setComment] = useState("");
   const [hasLocalEdits, setHasLocalEdits] = useState(false);
+  const existingRating = existing?.helpfulnessRating ?? null;
+  const existingComment = existing?.comment ?? "";
 
   useEffect(() => {
     if (hasLocalEdits) return;
-    setRating(existing?.helpfulnessRating ?? null);
-    setComment(existing?.comment ?? "");
-    setShowComment(!!existing?.comment);
-  }, [existing, hasLocalEdits]);
+    setRating(existingRating);
+    setComment(existingComment);
+  }, [existingRating, existingComment, hasLocalEdits]);
 
   useEffect(() => {
-    if (!rateMode) {
+    if (
+      hasLocalEdits &&
+      rating === existingRating &&
+      comment === existingComment
+    ) {
       setHasLocalEdits(false);
     }
-  }, [rateMode]);
+  }, [comment, existingComment, existingRating, hasLocalEdits, rating]);
 
   const hasComment = comment.trim().length > 0;
 
@@ -685,62 +758,87 @@ function InlineRateableResource({
     <span className="leading-relaxed text-zinc-300">{link.title}</span>
   );
 
-  if (!rateMode) {
-    return (
-      <div className="space-y-0.5">
-        <div className="flex items-center gap-2">
-          <div className="min-w-0 flex-1">{linkEl}</div>
-          <div className="flex shrink-0 items-center font-mono text-xs text-zinc-500">
-            {HELPFULNESS_RATINGS.map((r) => {
-              const count = link.ratingCounts[r];
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <div className="min-w-0 flex-1">{linkEl}</div>
+        <div className="ml-auto flex shrink-0 items-center gap-0.5 font-mono text-xs">
+          {HELPFULNESS_RATINGS.map((r) => {
+            const count = link.ratingCounts[r];
+            const isSelected = rating === r;
+            const baseClass =
+              "h-4 w-4 rounded border bg-transparent text-center leading-3.5 tabular-nums transition";
+            const selectedClass = "border-orange-500 text-orange-300";
+            const countClass =
+              count === 0
+                ? "border-transparent text-zinc-700"
+                : "border-transparent text-zinc-500";
+            const interactiveClass =
+              "hover:border-zinc-700 hover:text-zinc-300 focus-visible:border-zinc-700 focus-visible:ring-1 focus-visible:ring-orange-500/40 focus-visible:outline-none";
+            const className = `${baseClass} ${
+              isSelected
+                ? selectedClass
+                : canRate
+                  ? `${countClass} ${interactiveClass}`
+                  : countClass
+            }`;
+
+            if (!canRate) {
               return (
                 <span
                   key={r}
-                  className={`w-4 text-center tabular-nums ${
-                    count === 0 ? "text-zinc-700" : ""
-                  }`}
+                  className={className}
                   title={HELPFULNESS_RATING_HEADER_TITLES[r]}
                 >
                   {count}
                 </span>
               );
-            })}
-          </div>
-        </div>
-        {link.comment && (
-          <p className="text-xs text-zinc-500 italic">{link.comment}</p>
-        )}
-      </div>
-    );
-  }
+            }
 
-  return (
-    <div className="space-y-2">
-      <div className="flex flex-wrap items-center gap-2">
-        <div className="flex-1 truncate">{linkEl}</div>
-        <div className="ml-auto flex items-center gap-1">
-          <HelpfulnessSelect
-            value={rating}
-            onChange={(next) => {
-              setHasLocalEdits(true);
-              setRating(next);
-              void doUpsert({ helpfulnessRating: next });
-            }}
-          />
-          <button
-            type="button"
-            onClick={() => setShowComment((v) => !v)}
-            className={`w-6 shrink-0 rounded p-1 transition ${
-              hasComment
-                ? "text-orange-300 hover:bg-zinc-700/60"
-                : "text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300"
-            }`}
-            title={hasComment ? "Show comment" : "Add comment"}
-          >
-            <CommentIcon filled={hasComment} />
-          </button>
+            return (
+              <button
+                key={r}
+                type="button"
+                onClick={() => {
+                  const next = isSelected ? null : r;
+                  setHasLocalEdits(true);
+                  setRating(next);
+                  void doUpsert({ helpfulnessRating: next });
+                }}
+                className={className}
+                title={HELPFULNESS_RATING_HEADER_TITLES[r]}
+                aria-label={`Set resource rating: ${HELPFULNESS_RATING_HEADER_TITLES[r]}`}
+                aria-pressed={isSelected}
+              >
+                {count}
+              </button>
+            );
+          })}
+          {showCommentControl && (
+            <button
+              type="button"
+              onClick={() => {
+                if (!canRate) return;
+                setShowComment((v) => !v);
+              }}
+              className={`w-6 shrink-0 rounded p-1 transition focus-visible:ring-1 focus-visible:ring-orange-500/40 focus-visible:outline-none ${
+                hasComment
+                  ? "text-orange-500 hover:bg-zinc-700/60"
+                  : canRate
+                    ? "text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300"
+                    : "text-zinc-500"
+              }`}
+              title={hasComment ? "Show comment" : "Add comment"}
+              aria-disabled={!canRate}
+            >
+              <CommentIcon filled={hasComment} />
+            </button>
+          )}
         </div>
       </div>
+      {link.comment && (
+        <p className="text-xs text-zinc-500 italic">{link.comment}</p>
+      )}
       {showComment && (
         <DebouncedTextarea
           initialValue={comment}

--- a/src/features/topic-detail/TopicDetail.tsx
+++ b/src/features/topic-detail/TopicDetail.tsx
@@ -187,6 +187,11 @@ export function TopicDetail({
       { topicId: id, level: currentLevel ?? null },
       { enabled: hasResolvedViewerStatus && !Number.isNaN(id) },
     );
+  const { data: latestResourceFeedback } =
+    api.feedback.getLatestResourceFeedbackByTopic.useQuery(
+      { topicId: id },
+      { enabled: hasResolvedViewerStatus && !Number.isNaN(id) },
+    );
   const ensureManualTransition = useAppMutation(
     (
       opts: Exclude<
@@ -219,9 +224,13 @@ export function TopicDetail({
           topicId: input.topicId,
           level: currentLevel ?? null,
         };
+        const latestResourceFeedbackInput = { topicId: input.topicId };
         await Promise.all([
           utils.topic.getById.cancel({ id: input.topicId }),
           utils.feedback.getManualFeedbackByTopic.cancel(manualFeedbackInput),
+          utils.feedback.getLatestResourceFeedbackByTopic.cancel(
+            latestResourceFeedbackInput,
+          ),
         ]);
 
         const previousTopic = utils.topic.getById.getData({
@@ -229,8 +238,12 @@ export function TopicDetail({
         });
         const previousManualFeedback =
           utils.feedback.getManualFeedbackByTopic.getData(manualFeedbackInput);
+        const previousLatestResourceFeedback =
+          utils.feedback.getLatestResourceFeedbackByTopic.getData(
+            latestResourceFeedbackInput,
+          );
         const previousRating =
-          previousManualFeedback?.feedbackItems.find(
+          previousLatestResourceFeedback?.find(
             (item) =>
               item.type === "resource" &&
               item.topicLinkId === input.topicLinkId,
@@ -257,6 +270,42 @@ export function TopicDetail({
           } satisfies TopicDetailData;
         });
 
+        if (previousLatestResourceFeedback) {
+          utils.feedback.getLatestResourceFeedbackByTopic.setData(
+            latestResourceFeedbackInput,
+            (old) => {
+              if (!old) return old;
+              const existing = old.find(
+                (item) =>
+                  item.type === "resource" &&
+                  item.topicLinkId === input.topicLinkId,
+              );
+              if (existing) {
+                return old.map((item) =>
+                  item.type === "resource" &&
+                  item.topicLinkId === input.topicLinkId
+                    ? {
+                        ...item,
+                        helpfulnessRating: input.helpfulnessRating ?? null,
+                      }
+                    : item,
+                );
+              }
+              if (input.helpfulnessRating == null) return old;
+              return [
+                ...old,
+                {
+                  id: input.id ?? -input.topicLinkId,
+                  type: "resource" as const,
+                  topicLinkId: input.topicLinkId,
+                  helpfulnessRating: input.helpfulnessRating,
+                  comment: null,
+                },
+              ];
+            },
+          );
+        }
+
         if (previousManualFeedback) {
           utils.feedback.getManualFeedbackByTopic.setData(
             manualFeedbackInput,
@@ -281,8 +330,10 @@ export function TopicDetail({
 
         return {
           manualFeedbackInput,
+          latestResourceFeedbackInput,
           previousTopic,
           previousManualFeedback,
+          previousLatestResourceFeedback,
         };
       },
       onError: (error, _vars, ctx) => {
@@ -292,8 +343,10 @@ export function TopicDetail({
                 topicId: number;
                 level: UnderstandingLevel | null;
               };
+              latestResourceFeedbackInput: { topicId: number };
               previousTopic?: TopicDetailData;
               previousManualFeedback?: ManualFeedbackData;
+              previousLatestResourceFeedback?: LatestResourceFeedbackData;
             }
           | undefined;
         if (context) {
@@ -305,17 +358,25 @@ export function TopicDetail({
             context.manualFeedbackInput,
             context.previousManualFeedback,
           );
+          utils.feedback.getLatestResourceFeedbackByTopic.setData(
+            context.latestResourceFeedbackInput,
+            context.previousLatestResourceFeedback,
+          );
         }
         showGlobalErrorToast(
           getErrorMessage(error, "Failed to save resource feedback."),
         );
       },
-      refresh: [() => utils.feedback.getManualFeedbackByTopic.invalidate()],
+      refresh: [
+        () => utils.feedback.getManualFeedbackByTopic.invalidate(),
+        () => utils.feedback.getLatestResourceFeedbackByTopic.invalidate(),
+      ],
     },
   );
   const canRateResources =
     hasResolvedViewerStatus &&
     manualFeedback !== undefined &&
+    latestResourceFeedback !== undefined &&
     !ensureManualTransition.isPending &&
     !upsertManualFeedback.isPending;
   const showResourceFeedbackControls = !!viewerUser;
@@ -483,6 +544,7 @@ export function TopicDetail({
                       canRate={canRateResources}
                       showCommentControl={showResourceFeedbackControls}
                       manualFeedbackItems={manualFeedback?.feedbackItems ?? []}
+                      latestResourceFeedbackItems={latestResourceFeedback ?? []}
                       onUpsert={async (input) => {
                         let transitionId = manualFeedback?.transitionId ?? null;
                         if (transitionId == null) {
@@ -672,6 +734,8 @@ function RelatedTopicChip({
 type ManualFeedbackItem =
   RouterOutputs["feedback"]["getManualFeedbackByTopic"]["feedbackItems"][number];
 type ManualFeedbackData = RouterOutputs["feedback"]["getManualFeedbackByTopic"];
+type LatestResourceFeedbackData =
+  RouterOutputs["feedback"]["getLatestResourceFeedbackByTopic"];
 type TopicDetailData = NonNullable<RouterOutputs["topic"]["getById"]>;
 
 type ManualResourceUpsertInput = {
@@ -689,6 +753,7 @@ function InlineRateableResource({
   canRate,
   showCommentControl,
   manualFeedbackItems,
+  latestResourceFeedbackItems,
   onUpsert,
 }: {
   link: {
@@ -701,19 +766,23 @@ function InlineRateableResource({
   canRate: boolean;
   showCommentControl: boolean;
   manualFeedbackItems: ManualFeedbackItem[];
+  latestResourceFeedbackItems: LatestResourceFeedbackData;
   onUpsert: (
     input: Omit<ManualResourceUpsertInput, "topicId" | "transitionId">,
   ) => Promise<void>;
 }) {
-  const existing = manualFeedbackItems.find(
+  const manualExisting = manualFeedbackItems.find(
+    (fi) => fi.type === "resource" && fi.topicLinkId === link.id,
+  );
+  const latestExisting = latestResourceFeedbackItems.find(
     (fi) => fi.type === "resource" && fi.topicLinkId === link.id,
   );
   const [showComment, setShowComment] = useState(false);
   const [rating, setRating] = useState<HelpfulnessRating | null>(null);
   const [comment, setComment] = useState("");
   const [hasLocalEdits, setHasLocalEdits] = useState(false);
-  const existingRating = existing?.helpfulnessRating ?? null;
-  const existingComment = existing?.comment ?? "";
+  const existingRating = latestExisting?.helpfulnessRating ?? null;
+  const existingComment = latestExisting?.comment ?? "";
 
   useEffect(() => {
     if (hasLocalEdits) return;
@@ -738,7 +807,7 @@ function InlineRateableResource({
     comment?: string | null;
   }) => {
     await onUpsert({
-      id: existing?.id,
+      id: manualExisting?.id,
       type: "resource",
       topicLinkId: link.id,
       ...patch,

--- a/src/scripts/merge-dev-db.ts
+++ b/src/scripts/merge-dev-db.ts
@@ -147,7 +147,9 @@ for (const [discordId, devUserId] of devDiscordToUserId) {
   }
 }
 
-console.log(`Mapped ${devToLive.size} users (${unmatched} still unmatched — no Discord account in dump).\n`);
+console.log(
+  `Mapped ${devToLive.size} users (${unmatched} still unmatched — no Discord account in dump).\n`,
+);
 if (devToLive.size === 0) {
   console.log("Nothing to migrate.");
   process.exit(0);
@@ -159,15 +161,19 @@ if (devToLive.size === 0) {
 console.log("Validating topic and topic_link IDs…");
 
 const liveTopicRows = await live.execute("SELECT id FROM topic");
-const liveTopicIds = new Set<number>(liveTopicRows.rows.map((r) => r.id as number));
+const liveTopicIds = new Set<number>(
+  liveTopicRows.rows.map((r) => r.id as number),
+);
 
 const liveTopicLinkRows = await live.execute("SELECT id FROM topic_link");
-const liveTopicLinkIds = new Set<number>(liveTopicLinkRows.rows.map((r) => r.id as number));
+const liveTopicLinkIds = new Set<number>(
+  liveTopicLinkRows.rows.map((r) => r.id as number),
+);
 
 const devTopicIds = new Set<number>(
-  srcAll("SELECT DISTINCT topicId FROM user_topic_status UNION SELECT DISTINCT topicId FROM bookmark UNION SELECT DISTINCT topicId FROM level_transition UNION SELECT DISTINCT topicId FROM feedback_item").map(
-    (r) => r.topicId as number,
-  ),
+  srcAll(
+    "SELECT DISTINCT topicId FROM user_topic_status UNION SELECT DISTINCT topicId FROM bookmark UNION SELECT DISTINCT topicId FROM level_transition UNION SELECT DISTINCT topicId FROM feedback_item",
+  ).map((r) => r.topicId as number),
 );
 const missingTopicIds = [...devTopicIds].filter((id) => !liveTopicIds.has(id));
 if (missingTopicIds.length > 0) {
@@ -180,11 +186,13 @@ if (missingTopicIds.length > 0) {
 }
 
 const devTopicLinkIds = new Set<number>(
-  srcAll("SELECT DISTINCT topicLinkId FROM feedback_item WHERE topicLinkId IS NOT NULL").map(
-    (r) => r.topicLinkId as number,
-  ),
+  srcAll(
+    "SELECT DISTINCT topicLinkId FROM feedback_item WHERE topicLinkId IS NOT NULL",
+  ).map((r) => r.topicLinkId as number),
 );
-const missingTopicLinkIds = [...devTopicLinkIds].filter((id) => !liveTopicLinkIds.has(id));
+const missingTopicLinkIds = [...devTopicLinkIds].filter(
+  (id) => !liveTopicLinkIds.has(id),
+);
 if (missingTopicLinkIds.length > 0) {
   console.warn(
     `  WARNING: ${missingTopicLinkIds.length} topic_link IDs in the dump are missing from the live DB: ${missingTopicLinkIds.join(", ")}`,
@@ -213,7 +221,9 @@ async function liveExecute(query: string, args: unknown[] = []) {
 // 1. user_topic_status
 // ---------------------------------------------------------------------------
 console.log("Migrating user_topic_status…");
-const devStatuses = srcAll("SELECT userId, topicId, level FROM user_topic_status");
+const devStatuses = srcAll(
+  "SELECT userId, topicId, level FROM user_topic_status",
+);
 
 // Fetch live statuses for matched users
 const liveUserIds = [...devToLive.values()];
@@ -222,7 +232,10 @@ const liveStatusRows = await live.execute({
   args: liveUserIds,
 });
 const liveStatusMap = new Map<string, string>(
-  liveStatusRows.rows.map((r) => [`${r.userId as string}:${r.topicId as number}`, r.level as string]),
+  liveStatusRows.rows.map((r) => [
+    `${r.userId as string}:${r.topicId as number}`,
+    r.level as string,
+  ]),
 );
 
 let statusInserted = 0;
@@ -232,7 +245,10 @@ let statusSkipped = 0;
 for (const row of devStatuses) {
   const liveUserId = mapUserId(row.userId as string);
   if (!liveUserId) continue;
-  if (missingTopicIdSet.has(row.topicId as number)) { statusSkipped++; continue; }
+  if (missingTopicIdSet.has(row.topicId as number)) {
+    statusSkipped++;
+    continue;
+  }
 
   const key = `${liveUserId}:${row.topicId}`;
   const existingLevel = liveStatusMap.get(key);
@@ -313,11 +329,23 @@ let transitionSkipped = 0;
 
 for (const row of devTransitions) {
   const liveUserId = mapUserId(row.userId as string);
-  if (!liveUserId) { transitionSkipped++; continue; }
-  if (missingTopicIdSet.has(row.topicId as number)) { transitionSkipped++; continue; }
+  if (!liveUserId) {
+    transitionSkipped++;
+    continue;
+  }
+  if (missingTopicIdSet.has(row.topicId as number)) {
+    transitionSkipped++;
+    continue;
+  }
   const result = await liveExecute(
     "INSERT INTO level_transition (userId, topicId, fromLevel, toLevel, createdAt) VALUES (?, ?, ?, ?, ?)",
-    [liveUserId, row.topicId, row.fromLevel ?? null, row.toLevel ?? null, row.createdAt],
+    [
+      liveUserId,
+      row.topicId,
+      row.fromLevel ?? null,
+      row.toLevel ?? null,
+      row.createdAt,
+    ],
   );
   devTransitionIdToLive.set(
     row.id as number,
@@ -339,8 +367,14 @@ let feedbackSkipped = 0;
 
 for (const row of devFeedback) {
   const liveUserId = mapUserId(row.userId as string);
-  if (!liveUserId) { feedbackSkipped++; continue; }
-  if (missingTopicIdSet.has(row.topicId as number)) { feedbackSkipped++; continue; }
+  if (!liveUserId) {
+    feedbackSkipped++;
+    continue;
+  }
+  if (missingTopicIdSet.has(row.topicId as number)) {
+    feedbackSkipped++;
+    continue;
+  }
 
   // Translate transitionId
   const devTransId = row.transitionId as number | null;

--- a/src/server/api/routers/feedback.ts
+++ b/src/server/api/routers/feedback.ts
@@ -8,6 +8,7 @@ import {
   helpfulnessRatingSchema,
   SKIP_FEEDBACK_SENTINEL,
 } from "~/shared/feedbackTypes";
+import { selectLatestResourceVotes } from "~/server/api/routers/topic.helpers";
 import {
   understandingLevelSchema,
   type UnderstandingLevel,
@@ -146,6 +147,43 @@ async function findLatestSameStateTransition(args: {
 }
 
 export const feedbackRouter = createTRPCRouter({
+  getLatestResourceFeedbackByTopic: protectedProcedure
+    .input(z.object({ topicId: z.number() }))
+    .query(async ({ ctx, input }) => {
+      const rows = await ctx.db.query.feedbackItem.findMany({
+        where: (fi, { and, eq }) =>
+          and(
+            eq(fi.userId, ctx.session.user.id),
+            eq(fi.topicId, input.topicId),
+            eq(fi.type, "resource"),
+          ),
+        columns: {
+          id: true,
+          userId: true,
+          topicLinkId: true,
+          helpfulnessRating: true,
+          comment: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
+
+      return [
+        ...selectLatestResourceVotes(
+          rows.map((row) => ({
+            ...row,
+            rating: row.helpfulnessRating,
+          })),
+        ),
+      ].map((item) => ({
+        id: item.id,
+        type: "resource" as const,
+        topicLinkId: item.topicLinkId,
+        helpfulnessRating: item.rating,
+        comment: item.comment,
+      }));
+    }),
+
   getManualFeedbackByTopic: protectedProcedure
     .input(
       z.object({

--- a/src/server/api/routers/topic.helpers.ts
+++ b/src/server/api/routers/topic.helpers.ts
@@ -1,4 +1,5 @@
 import type { UnderstandingLevel } from "~/shared/understandingLevels";
+import type { HelpfulnessRating } from "~/shared/feedbackTypes";
 
 const TEACHER_LEVEL_RANK: Record<UnderstandingLevel, number> = {
   advanced_questions_welcome: 0,
@@ -23,4 +24,47 @@ export function compareTeachers(a: TeacherSortRow, b: TeacherSortRow): number {
   const levelDelta = TEACHER_LEVEL_RANK[a.level] - TEACHER_LEVEL_RANK[b.level];
   if (levelDelta !== 0) return levelDelta;
   return Number(b.available) - Number(a.available);
+}
+
+export type ResourceVoteRow = {
+  id: number;
+  userId: string;
+  topicLinkId: number | null;
+  rating: HelpfulnessRating | null;
+  createdAt: Date;
+  updatedAt: Date | null;
+};
+
+export function selectLatestResourceVotes(rows: ResourceVoteRow[]) {
+  const latestVote = new Map<
+    string,
+    {
+      id: number;
+      topicLinkId: number;
+      rating: HelpfulnessRating | null;
+      timestamp: number;
+    }
+  >();
+
+  for (const row of rows) {
+    if (row.topicLinkId == null) continue;
+    const key = `${row.userId}:${row.topicLinkId}`;
+    const timestamp = (row.updatedAt ?? row.createdAt).getTime();
+    const previous = latestVote.get(key);
+    if (
+      previous &&
+      (previous.timestamp > timestamp ||
+        (previous.timestamp === timestamp && previous.id > row.id))
+    ) {
+      continue;
+    }
+    latestVote.set(key, {
+      id: row.id,
+      topicLinkId: row.topicLinkId,
+      rating: row.rating,
+      timestamp,
+    });
+  }
+
+  return latestVote.values();
 }

--- a/src/server/api/routers/topic.helpers.ts
+++ b/src/server/api/routers/topic.helpers.ts
@@ -31,6 +31,7 @@ export type ResourceVoteRow = {
   userId: string;
   topicLinkId: number | null;
   rating: HelpfulnessRating | null;
+  comment?: string | null;
   createdAt: Date;
   updatedAt: Date | null;
 };
@@ -42,6 +43,7 @@ export function selectLatestResourceVotes(rows: ResourceVoteRow[]) {
       id: number;
       topicLinkId: number;
       rating: HelpfulnessRating | null;
+      comment: string | null;
       timestamp: number;
     }
   >();
@@ -62,6 +64,7 @@ export function selectLatestResourceVotes(rows: ResourceVoteRow[]) {
       id: row.id,
       topicLinkId: row.topicLinkId,
       rating: row.rating,
+      comment: row.comment ?? null,
       timestamp,
     });
   }

--- a/src/server/api/routers/topic.test.ts
+++ b/src/server/api/routers/topic.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { compareTeachers, type TeacherSortRow } from "./topic.helpers";
+import {
+  compareTeachers,
+  selectLatestResourceVotes,
+  type ResourceVoteRow,
+  type TeacherSortRow,
+} from "./topic.helpers";
 
 function label(row: TeacherSortRow): string {
   const parts = [
@@ -43,6 +48,102 @@ describe("compareTeachers", () => {
       "avail+not-excited+advanced_questions_welcome",
       "not-avail+not-excited+advanced_questions_welcome",
       "avail+not-excited+can_teach",
+    ]);
+  });
+});
+
+describe("selectLatestResourceVotes", () => {
+  it("treats an updated existing feedback row as the latest vote", () => {
+    const rows: ResourceVoteRow[] = [
+      {
+        id: 10,
+        userId: "user-1",
+        topicLinkId: 1,
+        rating: "really_helpful",
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+        updatedAt: new Date("2026-01-03T00:00:00Z"),
+      },
+      {
+        id: 11,
+        userId: "user-1",
+        topicLinkId: 1,
+        rating: "actively_unhelpful",
+        createdAt: new Date("2026-01-02T00:00:00Z"),
+        updatedAt: null,
+      },
+    ];
+
+    const votes = [...selectLatestResourceVotes(rows)];
+
+    expect(votes).toMatchObject([
+      {
+        id: 10,
+        topicLinkId: 1,
+        rating: "really_helpful",
+      },
+    ]);
+  });
+
+  it("falls back to createdAt when updatedAt is null", () => {
+    const rows: ResourceVoteRow[] = [
+      {
+        id: 10,
+        userId: "user-1",
+        topicLinkId: 1,
+        rating: "really_helpful",
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+        updatedAt: null,
+      },
+      {
+        id: 11,
+        userId: "user-1",
+        topicLinkId: 1,
+        rating: "actively_unhelpful",
+        createdAt: new Date("2026-01-02T00:00:00Z"),
+        updatedAt: null,
+      },
+    ];
+
+    const votes = [...selectLatestResourceVotes(rows)];
+
+    expect(votes).toMatchObject([
+      {
+        id: 11,
+        topicLinkId: 1,
+        rating: "actively_unhelpful",
+      },
+    ]);
+  });
+
+  it("uses id as a tie-breaker for equal timestamps", () => {
+    const timestamp = new Date("2026-01-01T00:00:00Z");
+    const rows: ResourceVoteRow[] = [
+      {
+        id: 10,
+        userId: "user-1",
+        topicLinkId: 1,
+        rating: "really_helpful",
+        createdAt: timestamp,
+        updatedAt: null,
+      },
+      {
+        id: 11,
+        userId: "user-1",
+        topicLinkId: 1,
+        rating: "actively_unhelpful",
+        createdAt: timestamp,
+        updatedAt: null,
+      },
+    ];
+
+    const votes = [...selectLatestResourceVotes(rows)];
+
+    expect(votes).toMatchObject([
+      {
+        id: 11,
+        topicLinkId: 1,
+        rating: "actively_unhelpful",
+      },
     ]);
   });
 });

--- a/src/server/api/routers/topic.ts
+++ b/src/server/api/routers/topic.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { and, eq, inArray } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { TEACHER_LEVELS } from "~/shared/understandingLevels";
-import { compareTeachers } from "./topic.helpers";
+import { compareTeachers, selectLatestResourceVotes } from "./topic.helpers";
 import {
   HELPFULNESS_RATINGS,
   type HelpfulnessRating,
@@ -96,12 +96,16 @@ export const topicRouter = createTRPCRouter({
       const countsByLink = new Map<number, RatingCounts>();
       if (linkIds.length > 0) {
         // One vote per (user, topicLink). A user may have rated the same link
-        // across multiple level transitions — keep the latest row by id.
+        // across multiple level transitions. Updates to an existing row are also
+        // new votes, so recency must use timestamps before falling back to id.
         const rows = await ctx.db
           .select({
+            id: feedbackItem.id,
             topicLinkId: feedbackItem.topicLinkId,
             userId: feedbackItem.userId,
             rating: feedbackItem.helpfulnessRating,
+            createdAt: feedbackItem.createdAt,
+            updatedAt: feedbackItem.updatedAt,
           })
           .from(feedbackItem)
           .where(
@@ -109,20 +113,8 @@ export const topicRouter = createTRPCRouter({
               eq(feedbackItem.type, "resource"),
               inArray(feedbackItem.topicLinkId, linkIds),
             ),
-          )
-          .orderBy(feedbackItem.id);
-        const latestVote = new Map<
-          string,
-          { topicLinkId: number; rating: HelpfulnessRating | null }
-        >();
-        for (const row of rows) {
-          if (row.topicLinkId == null) continue;
-          latestVote.set(`${row.userId}:${row.topicLinkId}`, {
-            topicLinkId: row.topicLinkId,
-            rating: row.rating,
-          });
-        }
-        for (const { topicLinkId, rating } of latestVote.values()) {
+          );
+        for (const { topicLinkId, rating } of selectLatestResourceVotes(rows)) {
           if (rating == null) continue;
           let counts = countsByLink.get(topicLinkId);
           if (!counts) {


### PR DESCRIPTION
* replacement of "edit mode" for more intuitive UX
* seeing my latest rating doubles as "mark as read" indicator (to see which resources I haven't rated yet)
* based on feedback in https://discord.com/channels/1254141711429402774/1497597688701780119/1504417810955243530
<img width="927" height="218" alt="image" src="https://github.com/user-attachments/assets/b2a663b2-c1b0-4664-a8fd-b62caf1a44b6" />
